### PR TITLE
Added asyncMap

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -25,3 +25,15 @@ SOFTWARE.
 # CombineAsyncStream License
 
 CombineAsyncStream was created by Marin Todorov. It was released on his blog at: https://trycombine.com/posts/combine-async-sequence-2/.
+
+# asyncMap License 
+
+MIT License
+
+Copyright (c) 2021 John Sundell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Sources/AsyncExtensions/AsyncMap.swift
+++ b/Sources/AsyncExtensions/AsyncMap.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// This function was taken from `CollectionConcurrencyKit` by John Sundell.
 /// https://github.com/JohnSundell/CollectionConcurrencyKit/blob/main/Sources/CollectionConcurrencyKit.swift
-///
 extension Sequence {
     func asyncMap<T>(
         _ transform: (Element) async throws -> T

--- a/Sources/AsyncExtensions/AsyncMap.swift
+++ b/Sources/AsyncExtensions/AsyncMap.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// This function was taken from `CollectionConcurrencyKit` by John Sundell.
+/// https://github.com/JohnSundell/CollectionConcurrencyKit/blob/main/Sources/CollectionConcurrencyKit.swift
+///
+extension Sequence {
+    func asyncMap<T>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+
+        for element in self {
+            try await values.append(transform(element))
+        }
+
+        return values
+    }
+}


### PR DESCRIPTION
This PR adds `asyncMap` function as an async version of the standard high-order `map` function.