### PR TITLE
Add Future

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,9 @@ let package = Package(
     targets: [
         .target(
             name: "AsyncExtensions",
-            dependencies: []
+            dependencies: [
+                .product(name: "Synchronized", package: "synchronized"),
+            ]
         ),
         .testTarget(
             name: "AsyncExtensionsTests",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The AsyncExtensions package also inlcudes the AsyncTestExtensions target, which 
 ## AsyncExtensions includes
 
 - `AsyncInputStream`: A convenient wrapper around [`InputStream`](https://developer.apple.com/documentation/foundation/inputstream) allowing for simple, type-safe access to stream data.
+- `CombineAsyncStream`: A backported version of [`AsyncPublisher`](https://developer.apple.com/documentation/combine/asyncpublisher), which creates an `AsyncStream` from a Combine Publisher and is only supported on iOS 15+.
+- `Future`: A thread-safe implemention of a future that is useful when briding traditional Swift code with code employing Swift Concurrency.
+- `Sequence.asyncMap()` and `Sequence.concurrentMap()`: Extensions allowing for applying async transformations to `Sequence`.
+- `TimeoutError`: A simple error intending to represent a timeout. Modelled after [`CancellationError`](https://developer.apple.com/documentation/swift/cancellationerror).
 
 ## AsyncTestExtensions includes
 
@@ -28,9 +32,8 @@ To use AsyncExtensions, add a dependency to your Package.swift file:
 let package = Package(
   dependencies: [
     .package(
-      name: "AsyncExtensions",
       url: "https://github.com/shareup/async-extensions.git",
-      from: "1.1.0"
+      from: "2.0.0"
     )
   ]
 )
@@ -42,7 +45,7 @@ To use AsyncTestExtensions in a test target, add it as a dependency:
 .testTarget(
   name: "MyTests",
   dependencies: [
-    .product(name: "AsyncTestExtensions", package: "AsyncExtensions")
+    .product(name: "AsyncTestExtensions", package: "async-extensions")
   ]
 )
 ```
@@ -51,4 +54,6 @@ To use AsyncTestExtensions in a test target, add it as a dependency:
 
 The license for AsyncExtensions is the standard MIT licence. You can find it in the LICENSE file.
 
-CombineAsyncStream was created by Marin Todorov. It was released on his blog at: https://trycombine.com/posts/combine-async-sequence-2/.
+CombineAsyncStream was created by Marin Todorov. It was released on his blog at https://trycombine.com/posts/combine-async-sequence-2/.
+
+SequenceExtensions were heavily inspired by CollectionConcurrencyKit by John Sundell at https://github.com/JohnSundell/CollectionConcurrencyKit.

--- a/Sources/AsyncExtensions/Future.swift
+++ b/Sources/AsyncExtensions/Future.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Synchronized
+
+public final class Future<T: Sendable>: @unchecked Sendable {
+    private let result = Locked<Result<T, Error>?>(nil)
+    private let continuations = Locked<[UnsafeContinuation<T, Error>]>([])
+
+    public init() {}
+
+    public init(_ block: @escaping () async throws -> T) {
+        Task {
+            do {
+                let value = try await block()
+                self.resolve(value)
+            } catch {
+                self.fail(error)
+            }
+        }
+    }
+
+    public init(_ block: (@escaping (Result<T, Error>) -> Void) -> Void) {
+        block { result in
+            switch result {
+            case let .success(value):
+                self.resolve(value)
+
+            case let .failure(error):
+                self.fail(error)
+            }
+        }
+    }
+
+    public var value: T { get async throws {
+        try await withUnsafeThrowingContinuation { cont in
+            if let result = result.access({ $0 }) {
+                cont.resume(with: result)
+            } else {
+                continuations.access { $0.append(cont) }
+                // If the result was set while adding our continuation to
+                // the array of continuations, we need to resume it.
+                resumeContinuations()
+            }
+        }
+    }}
+
+    public func resolve(_ value: T) {
+        result.access { result in
+            guard result == nil else { return }
+            result = .success(value)
+        }
+        resumeContinuations()
+    }
+
+    public func fail(_ error: Error) {
+        result.access { result in
+            guard result == nil else { return }
+            result = .failure(error)
+        }
+        resumeContinuations()
+    }
+
+    private func resumeContinuations() {
+        guard let result = result.access({ $0 }) else { return }
+        let continuations = continuations.access { continuations in
+            let conts = continuations
+            continuations.removeAll()
+            return conts
+        }
+        continuations.forEach { $0.resume(with: result) }
+    }
+}

--- a/Sources/AsyncExtensions/SequenceExtensions.swift
+++ b/Sources/AsyncExtensions/SequenceExtensions.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// These functions was taken from `CollectionConcurrencyKit` by John Sundell.
+/// These functions were inspired by `CollectionConcurrencyKit` by John Sundell.
 /// https://github.com/JohnSundell/CollectionConcurrencyKit/blob/main/Sources/CollectionConcurrencyKit.swift
 public extension Sequence {
     func asyncMap<T>(
@@ -16,10 +16,11 @@ public extension Sequence {
     }
 
     func concurrentMap<T>(
+        priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async throws -> T
     ) async throws -> [T] {
         let tasks = map { element in
-            Task {
+            Task(priority: priority) {
                 try await transform(element)
             }
         }

--- a/Tests/AsyncExtensionsTests/FutureTests.swift
+++ b/Tests/AsyncExtensionsTests/FutureTests.swift
@@ -1,0 +1,209 @@
+import AsyncExtensions
+import XCTest
+
+final class FutureTests: XCTestCase {
+    func testResolveBeforeAwaiting() async throws {
+        let future = Future<Int>()
+        future.resolve(1)
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testFailBeforeAwaiting() async throws {
+        let future = Future<Int>()
+        future.fail(TestError())
+        do {
+            let value = try await future.value
+            XCTFail("Should not have received \(value)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testResolveAfterAwaiting() async throws {
+        let future = Future<Int>()
+        later { future.resolve(1) }
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testFailAfterAwaiting() async throws {
+        let future = Future<Int>()
+        later { future.fail(TestError()) }
+        do {
+            let value = try await future.value
+            XCTFail("Should not have received \(value)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testResolvingMultipleTimesIsNoop() async throws {
+        let future = Future<Int>()
+        future.resolve(1)
+        future.resolve(2)
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testFailingMultipleTimesIsNoop() async throws {
+        let future = Future<Int>()
+        future.fail(TestError())
+        future.fail(CancellationError())
+        do {
+            let value = try await future.value
+            XCTFail("Should not have received \(value)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testFailingAfterResolvingIsNoop() async throws {
+        let future = Future<Int>()
+        future.resolve(1)
+        future.fail(TestError())
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testResolvingAfterFailingIsNoop() async throws {
+        let future = Future<Int>()
+        future.fail(TestError())
+        future.resolve(1)
+        do {
+            let value = try await future.value
+            XCTFail("Should not have received \(value)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testResolvingWithMultipleAwaits() async throws {
+        let future = Future<Int>()
+
+        async let await1 = future.value
+        async let await2 = future.value
+
+        later { future.resolve(1) }
+
+        let (value1, value2) = try await (await1, await2)
+        XCTAssertEqual(1, value1)
+        XCTAssertEqual(1, value2)
+    }
+
+    func testFailingWithMultipleAwaits() async throws {
+        let future = Future<Int>()
+
+        async let await1 = future.value
+        async let await2 = future.value
+
+        later { future.fail(TestError()) }
+
+        do {
+            let (value1, value2) = try await (await1, await2)
+            XCTFail("Should not have received \(value1) or \(value2)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testInitWithAsyncBlock() async throws {
+        let future = Future<Int> { () async throws -> Int in
+            try await Task.sleep(nanoseconds: 20 * NSEC_PER_MSEC)
+            return 1
+        }
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testInitWithFailingAsyncBlock() async throws {
+        let future = Future<Int> { () async throws -> Int in
+            try await Task.sleep(nanoseconds: 20 * NSEC_PER_MSEC)
+            throw TestError()
+        }
+        do {
+            let value = try await future.value
+            XCTFail("Should not have received \(value)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testInitWithBlock() async throws {
+        let future = Future<Int> { completion in
+            later { completion(.success(1)) }
+        }
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testInitWithFailingBlock() async throws {
+        let future = Future<Int> { completion in
+            later { completion(.failure(TestError())) }
+        }
+        do {
+            let value = try await future.value
+            XCTFail("Should not have received \(value)")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testResolvingWithManyAwaits() async throws {
+        let future = Future<Int> { completion in
+            later(milliseconds: 1) { completion(.success(1)) }
+        }
+
+        let count = 1000
+        let results = await withThrowingTaskGroup(of: Int.self) { group in
+            (0 ..< count).forEach { _ in group.addTask { try await future.value } }
+
+            var results: [Result<Int, Error>] = []
+            while let result = await group.nextResult() {
+                results.append(result)
+            }
+            return results
+        }
+
+        XCTAssertEqual(count, results.count)
+        XCTAssertTrue(results.allSatisfy { result in
+            guard case .success(1) = result else { return false }
+            return true
+        })
+    }
+
+    func testFailingWithManyAwaits() async throws {
+        let future = Future<Int> { completion in
+            later(milliseconds: 1) { completion(.failure(TestError())) }
+        }
+
+        let count = 1000
+        let results = await withThrowingTaskGroup(of: Int.self) { group in
+            (0 ..< count).forEach { _ in group.addTask { try await future.value } }
+
+            var results: [Result<Int, Error>] = []
+            while let result = await group.nextResult() {
+                results.append(result)
+            }
+            return results
+        }
+
+        XCTAssertEqual(count, results.count)
+        XCTAssertTrue(results.allSatisfy { result in
+            if case let .failure(error) = result {
+                return error is TestError
+            } else {
+                return false
+            }
+        })
+    }
+}
+
+private func later(milliseconds: Int = 20, _ block: @escaping () -> Void) {
+    DispatchQueue.global().asyncAfter(
+        deadline: .now() + .milliseconds(milliseconds),
+        execute: block
+    )
+}
+
+private struct TestError: Error {}


### PR DESCRIPTION
`Future` is useful for bridging traditional asynchronous Swift code and asynchronous code employing Swift Concurrency. It's also a useful construct when writing tests.