### PR TITLE
Improve Future

### DIFF
--- a/Sources/AsyncExtensions/Future.swift
+++ b/Sources/AsyncExtensions/Future.swift
@@ -19,7 +19,7 @@ Sendable {
         Task {
             await withThrowingTaskGroup(of: Void.self) { group in
                 let _ = group.addTaskUnlessCancelled { [weak self] in
-                    // TODO: Replace this with `Clock` when iOS 15 is minimum
+                    // TODO: Replace this with `Clock` when iOS 16 is minimum
                     let timeoutNs = Double(NSEC_PER_SEC) * timeout
                     try await Task.sleep(nanoseconds: UInt64(timeoutNs))
                     self?.fail(TimeoutError())

--- a/Sources/AsyncExtensions/Future.swift
+++ b/Sources/AsyncExtensions/Future.swift
@@ -91,7 +91,9 @@ public extension Future {
 }
 
 public extension Future where T == Void {
-    func resolve() { resolve(()) }
+    func resolve() {
+        resolve(())
+    }
 }
 
 private extension Future {

--- a/Sources/AsyncExtensions/Future.swift
+++ b/Sources/AsyncExtensions/Future.swift
@@ -1,71 +1,103 @@
 import Foundation
 import Synchronized
 
-public final class Future<T: Sendable>: @unchecked Sendable {
-    private let result = Locked<Result<T, Error>?>(nil)
-    private let continuations = Locked<[UnsafeContinuation<T, Error>]>([])
+public final class Future<T: Sendable>: @unchecked
+Sendable {
+    fileprivate typealias R = Result<T, Error>
+    fileprivate typealias C = UnsafeContinuation<T, Error>
+    fileprivate typealias Cs = [String: C]
+
+    private let state = Locked(State())
 
     public init() {}
 
-    public init(_ block: @escaping () async throws -> T) {
-        Task {
-            do {
-                let value = try await block()
-                self.resolve(value)
-            } catch {
-                self.fail(error)
-            }
-        }
-    }
-
-    public init(_ block: (@escaping (Result<T, Error>) -> Void) -> Void) {
-        block { result in
-            switch result {
-            case let .success(value):
-                self.resolve(value)
-
-            case let .failure(error):
-                self.fail(error)
-            }
-        }
-    }
-
     public var value: T { get async throws {
-        try await withUnsafeThrowingContinuation { cont in
-            if let result = result.access({ $0 }) {
-                cont.resume(with: result)
-            } else {
-                continuations.access { $0.append(cont) }
-                // If the result was set while adding our continuation to
-                // the array of continuations, we need to resume it.
-                resumeContinuations()
+        let id = UUID().uuidString
+
+        return try await withTaskCancellationHandler(
+            operation: {
+                try await withUnsafeThrowingContinuation { cont in
+                    let resultOrIsCancelled: (R?, Bool) =
+                        state.access { state in
+                            if state.cancelled.contains(id) {
+                                return (nil, true)
+                            } else if let result = state.result {
+                                return (result, false)
+                            } else {
+                                state.continuations[id] = cont
+                                return (nil, false)
+                            }
+                        }
+
+                    if let result = resultOrIsCancelled.0 {
+                        cont.resume(with: result)
+                    } else if resultOrIsCancelled.1 {
+                        cont.resume(throwing: CancellationError())
+                    }
+
+                    resumeContinuations()
+                }
+            },
+            onCancel: {
+                let cont = state.access { state in
+                    state.cancelled.insert(id)
+                    return state
+                        .continuations
+                        .removeValue(forKey: id)
+                }
+                cont?.resume(throwing: CancellationError())
             }
-        }
+        )
     }}
 
     public func resolve(_ value: T) {
-        result.access { result in
-            guard result == nil else { return }
-            result = .success(value)
+        state.access { state in
+            guard state.result == nil else { return }
+            state.result = .success(value)
         }
         resumeContinuations()
     }
 
     public func fail(_ error: Error) {
-        result.access { result in
-            guard result == nil else { return }
-            result = .failure(error)
+        state.access { state in
+            guard state.result == nil else { return }
+            state.result = .failure(error)
         }
         resumeContinuations()
     }
 
     private func resumeContinuations() {
-        guard let result = result.access({ $0 }) else { return }
-        let continuations = continuations.access { continuations in
-            let conts = continuations
-            continuations.removeAll()
-            return conts
+        let rAndCs: (R, Cs)? = state.access { state in
+            guard let result = state.result else { return nil }
+            let conts = state.continuations
+            state.continuations.removeAll()
+            return (result, conts)
         }
-        continuations.forEach { $0.resume(with: result) }
+
+        guard let (result, continuations) = rAndCs else { return }
+        continuations.forEach { $0.value.resume(with: result) }
+    }
+}
+
+public extension Future {
+    var result: Result<T, Error> { get async {
+        do {
+            let value = try await value
+            return .success(value)
+        } catch {
+            return .failure(error)
+        }
+    }}
+}
+
+public extension Future where T == Void {
+    func resolve() { resolve(()) }
+}
+
+private extension Future {
+    struct State {
+        var result: R?
+        var continuations: Cs = [:]
+        var cancelled: Set<String> = []
     }
 }

--- a/Tests/AsyncExtensionsTests/FutureTests.swift
+++ b/Tests/AsyncExtensionsTests/FutureTests.swift
@@ -1,4 +1,5 @@
 import AsyncExtensions
+import Synchronized
 import XCTest
 
 final class FutureTests: XCTestCase {
@@ -107,51 +108,10 @@ final class FutureTests: XCTestCase {
         }
     }
 
-    func testInitWithAsyncBlock() async throws {
-        let future = Future<Int> { () async throws -> Int in
-            try await Task.sleep(nanoseconds: 20 * NSEC_PER_MSEC)
-            return 1
-        }
-        let value = try await future.value
-        XCTAssertEqual(1, value)
-    }
-
-    func testInitWithFailingAsyncBlock() async throws {
-        let future = Future<Int> { () async throws -> Int in
-            try await Task.sleep(nanoseconds: 20 * NSEC_PER_MSEC)
-            throw TestError()
-        }
-        do {
-            let value = try await future.value
-            XCTFail("Should not have received \(value)")
-        } catch {
-            XCTAssertTrue(error is TestError)
-        }
-    }
-
-    func testInitWithBlock() async throws {
-        let future = Future<Int> { completion in
-            later { completion(.success(1)) }
-        }
-        let value = try await future.value
-        XCTAssertEqual(1, value)
-    }
-
-    func testInitWithFailingBlock() async throws {
-        let future = Future<Int> { completion in
-            later { completion(.failure(TestError())) }
-        }
-        do {
-            let value = try await future.value
-            XCTFail("Should not have received \(value)")
-        } catch {
-            XCTAssertTrue(error is TestError)
-        }
-    }
-
     func testResolvingWithManyAwaits() async throws {
-        let future = Future<Int> { completion in
-            later(milliseconds: 1) { completion(.success(1)) }
+        let future = Future<Int>()
+        later(milliseconds: (1 ... 10).randomElement()!) {
+            future.resolve(1)
         }
 
         let count = 1000
@@ -173,8 +133,9 @@ final class FutureTests: XCTestCase {
     }
 
     func testFailingWithManyAwaits() async throws {
-        let future = Future<Int> { completion in
-            later(milliseconds: 1) { completion(.failure(TestError())) }
+        let future = Future<Int>()
+        later(milliseconds: (1 ... 10).randomElement()!) {
+            future.fail(TestError())
         }
 
         let count = 1000
@@ -196,6 +157,158 @@ final class FutureTests: XCTestCase {
                 return false
             }
         })
+    }
+
+    func testCancel() async throws {
+        let future = Future<Int>()
+        let didCancel = Future<Void>()
+
+        let task = Task {
+            do {
+                let value = try await future.value
+                XCTFail("Should not have resolved to \(value)")
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+                didCancel.resolve()
+            }
+        }
+
+        task.cancel()
+
+        try await didCancel.value
+    }
+
+    func testCancelOneAwaitAmongMany() async throws {
+        let future = Future<Int>()
+        let values = Locked<[Int]>([])
+
+        let taskToCancel = Task {
+            do {
+                let value = try await future.value
+                XCTFail("Should not have resolved to \(value)")
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+                future.resolve(1)
+            }
+        }
+
+        let taskToAwait1 = Task {
+            let value = try await future.value
+            values.access { $0.append(value) }
+        }
+
+        let taskToAwait2 = Task {
+            let value = try await future.value
+            values.access { $0.append(value) }
+        }
+
+        let taskToAwait3 = Task {
+            let value = try await future.value
+            values.access { $0.append(value) }
+        }
+
+        // Give the tasks an opportunity to await the future
+        try await Task.sleep(nanoseconds: NSEC_PER_MSEC * 20)
+
+        taskToCancel.cancel()
+
+        try await taskToAwait1.value
+        try await taskToAwait2.value
+        try await taskToAwait3.value
+
+        XCTAssertEqual([1, 1, 1], values.access { $0 })
+
+        let value = try await future.value
+        XCTAssertEqual(1, value)
+    }
+
+    func testRandomCancellations() async throws {
+        let count = 1000
+        let timeoutMs = 20
+
+        let shouldSucceed = Locked(0)
+        let didSucceed = Locked(0)
+        let didFail = Locked(0)
+
+        let future = Future<Int>()
+
+        later(milliseconds: timeoutMs) { future.resolve(1) }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            (0 ..< count).forEach { _ in
+                if Bool.random() {
+                    // This task will probably be cancelled
+                    group.addTask {
+                        let task = Task {
+                            do {
+                                let value = try await future.value
+                                XCTAssertEqual(1, value)
+                                didSucceed.access { $0 += 1 }
+                            } catch {
+                                XCTAssertTrue(error is CancellationError)
+                                didFail.access { $0 += 1 }
+                            }
+                        }
+
+                        let timeout = UInt64(Double(timeoutMs) * 0.8) * NSEC_PER_MSEC
+                        try await Task.sleep(nanoseconds: timeout)
+                        task.cancel()
+                    }
+
+                } else {
+                    // This task should definitely succeed
+                    shouldSucceed.access { $0 += 1 }
+                    group.addTask {
+                        let value = try await future.value
+                        XCTAssertEqual(1, value)
+                        didSucceed.access { $0 += 1 }
+                    }
+                }
+            }
+
+            try await group.waitForAll()
+        }
+
+        // `didSucceed` >= `shouldSucceed`
+        XCTAssertGreaterThanOrEqual(
+            didSucceed.access { $0 },
+            shouldSucceed.access { $0 }
+        )
+
+        XCTAssertEqual(
+            count,
+            didSucceed.access { $0 } + didFail.access { $0 }
+        )
+    }
+
+    func testResultWithValue() async throws {
+        let future = Future<Int>()
+        later { future.resolve(1) }
+
+        let result = await future.result
+
+        switch result {
+        case let .success(value):
+            XCTAssertEqual(1, value)
+
+        case let .failure(error):
+            XCTFail("Should not have received failure: \(error)")
+        }
+    }
+
+    func testResultWithFailure() async throws {
+        let future = Future<Int>()
+        later { future.fail(TestError()) }
+
+        let result = await future.result
+
+        switch result {
+        case let .success(value):
+            XCTFail("Should not have received success: \(value)")
+
+        case let .failure(error):
+            XCTAssertTrue(error is TestError)
+        }
     }
 }
 


### PR DESCRIPTION
- Add support for canceling waiting for future resolution
- Add `Future.init(timeout:)`
- Create only a single lock per future
- Add inline documentation to `Future`