### PR TITLE
Add TaskStore and tests

### DIFF
--- a/Sources/AsyncExtensions/TaskStore.swift
+++ b/Sources/AsyncExtensions/TaskStore.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Synchronized
+
+public extension Task {
+    @discardableResult
+    func store(in store: TaskStore) -> String {
+        store.add(self)
+    }
+
+    func store(forKey key: String, in store: TaskStore) {
+        store.insert(self, forKey: key)
+    }
+}
+
+public final class TaskStore: Hashable, @unchecked
+Sendable {
+    private let state = Locked(State())
+
+    public init() {}
+
+    deinit {
+        state.access { $0.cancelAll() }
+    }
+
+    @discardableResult
+    public func add(_ task: Task<some Any, some Any>) -> String {
+        let key = UUID().uuidString
+        state.access { $0.insert(task, forKey: key) }
+        return key
+    }
+
+    public func insert(_ task: Task<some Any, some Any>, forKey key: String) {
+        state.access { $0.insert(task, forKey: key) }
+    }
+
+    public func cancel(forKey key: String) {
+        state.access { $0.cancel(forKey: key) }
+    }
+
+    public func cancelAll() {
+        state.access { $0.cancelAll() }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: TaskStore, rhs: TaskStore) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    }
+}
+
+public extension TaskStore {
+    @discardableResult
+    func storedTask<S: Sendable>(
+        priority: TaskPriority? = nil,
+        operation: @escaping @Sendable () async -> S
+    ) -> String {
+        Task<S, Never>(priority: priority, operation: operation)
+            .store(in: self)
+    }
+
+    func storedTask<S: Sendable>(
+        key: String,
+        priority: TaskPriority? = nil,
+        operation: @escaping @Sendable () async -> S
+    ) {
+        Task<S, Never>(priority: priority, operation: operation)
+            .store(forKey: key, in: self)
+    }
+
+    @discardableResult
+    func storedTask(
+        priority: TaskPriority? = nil,
+        operation: @escaping @Sendable () async throws -> some Sendable
+    ) -> String {
+        Task(priority: priority, operation: operation)
+            .store(in: self)
+    }
+
+    func storedTask(
+        key: String,
+        priority: TaskPriority? = nil,
+        operation: @escaping @Sendable () async throws -> some Sendable
+    ) {
+        Task(priority: priority, operation: operation)
+            .store(forKey: key, in: self)
+    }
+}
+
+private struct State {
+    var tasks: [String: () -> Void] = [:]
+
+    mutating func insert(_ task: Task<some Any, some Any>, forKey key: String) {
+        cancel(forKey: key)
+        tasks[key] = { task.cancel() }
+    }
+
+    mutating func cancel(forKey key: String) {
+        if let cancel = tasks.removeValue(forKey: key) { cancel() }
+    }
+
+    mutating func cancelAll() {
+        tasks.values.forEach { $0() }
+        tasks.removeAll()
+    }
+}

--- a/Tests/AsyncExtensionsTests/TaskStoreTests.swift
+++ b/Tests/AsyncExtensionsTests/TaskStoreTests.swift
@@ -1,0 +1,95 @@
+import AsyncExtensions
+import XCTest
+
+final class TaskStoreTests: XCTestCase {
+    func testHashable() {
+        let store1 = TaskStore()
+        let store2 = TaskStore()
+
+        XCTAssertEqual(store1, store1)
+        XCTAssertNotEqual(store1, store2)
+        XCTAssertEqual(store2.hashValue, store2.hashValue)
+        XCTAssertNotEqual(store1.hashValue, store2.hashValue)
+    }
+
+    func testAddingMultipleDifferentTypesOfTasks() throws {
+        let store = TaskStore()
+
+        let ex1 = expectation(description: "Task 1 should have been cancelled")
+        let key1 = store.storedTask {
+            do {
+                try await Task.sleep(nanoseconds: NSEC_PER_SEC * 10)
+                XCTFail("Should not have completed")
+                return 1
+            } catch {
+                ex1.fulfill()
+                return 0
+            }
+        }
+        XCTAssertNotNil(UUID(uuidString: key1))
+
+        let ex2 = expectation(description: "Task 2 should have been cancelled")
+        let key2 = "second one"
+        store.storedTask(key: key2) {
+            do {
+                try await Task.sleep(nanoseconds: NSEC_PER_SEC * 10)
+                XCTFail("Should not have completed")
+                return "Nope"
+            } catch {
+                ex2.fulfill()
+                throw error
+            }
+        }
+
+        store.cancel(forKey: key2)
+        wait(for: [ex2], timeout: 2)
+
+        store.cancelAll()
+        wait(for: [ex1], timeout: 2)
+    }
+
+    func testAllTasksAreCancelledOnDeinitialization() throws {
+        let ex1 = expectation(description: "Task 1 should have been cancelled")
+        let ex2 = expectation(description: "Task 2 should have been cancelled")
+        let ex3 = expectation(description: "Task 3 should have been cancelled")
+
+        autoreleasepool {
+            let store = TaskStore()
+
+            store.storedTask {
+                do {
+                    try await Task.sleep(nanoseconds: NSEC_PER_SEC * 10)
+                    XCTFail("Should not have completed")
+                    return 1
+                } catch {
+                    ex1.fulfill()
+                    return 0
+                }
+            }
+
+            store.storedTask(key: "task2") {
+                do {
+                    try await Task.sleep(nanoseconds: NSEC_PER_SEC * 10)
+                    XCTFail("Should not have completed")
+                    return "Nope"
+                } catch {
+                    ex2.fulfill()
+                    return "Yep"
+                }
+            }
+
+            store.storedTask {
+                do {
+                    try await Task.sleep(nanoseconds: NSEC_PER_SEC * 10)
+                    XCTFail("Should not have completed")
+                    return Double(999.99)
+                } catch {
+                    ex3.fulfill()
+                    throw error
+                }
+            }
+        }
+
+        wait(for: [ex1, ex2, ex3], timeout: 2)
+    }
+}


### PR DESCRIPTION
`TaskStore` is intended to hold long-running `Task`s. It can be especially useful when migrating from Combine to Swift Concurrency because it solves the same problem as a `Set<AnyCancellable>` does for Combine subscriptions. Unlike `Set<AnyCancellable>`, `TaskStore` is thread-safe (i.e., `Sendable`).